### PR TITLE
Print code improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,20 @@ class Dsl
 end
 ```
 
-For other libraries where printing the code and context lines around the code is useful, you can use:
+## Print Code Helper
+
+For other libraries where printing the code and context lines around the code is useful, you can use `DslEvaluator.print_code`.
+
+The `print_code` method understands "polymorphic" arguments.
+
+1. If the caller line info is part of a standard ruby backtrace line. Example of this is in ufo [helpers/ecr.rb](https://github.com/boltops-tools/ufo/blob/master/lib/ufo/task_definition/helpers/ecr.rb)
+
+```ruby
+call_line = ufo_config_call_line
+DslEvaluator.print_code(call_line)
+```
+
+2. If the caller line info is custom.  Example of this is in ufo [erb/yaml.rb](https://github.com/boltops-tools/ufo/blob/9247b77c6ad2a3a6307155a2a130308a24668333/lib/ufo/task_definition/erb/yaml.rb#L16)
 
 ```ruby
 path = "replace with path to file"

--- a/lib/dsl_evaluator.rb
+++ b/lib/dsl_evaluator.rb
@@ -11,6 +11,7 @@ DslEvaluator::Autoloader.setup
 
 module DslEvaluator
   extend Memoist
+  include Printer::Concern
 
   class Error < StandardError; end
 
@@ -43,37 +44,6 @@ module DslEvaluator
     App.instance.config
   end
   memoize :config
-
-  # So other libraries can use this method
-  def print_code(path, line_number)
-    check_line_number!(line_number)
-    line_number = line_number.to_i
-    contents = IO.read(path)
-    content_lines = contents.split("\n")
-    context = 5 # lines of context
-    top, bottom = [line_number-context-1, 0].max, line_number+context-1
-    lpad = content_lines.size.to_s.size
-    content_lines[top..bottom].each_with_index do |line_content, index|
-      current_line = top+index+1
-      if current_line == line_number
-        printf("%#{lpad}d %s\n".color(:red), current_line, line_content)
-      else
-        printf("%#{lpad}d %s\n", current_line, line_content)
-      end
-    end
-
-    logger.info "Rerun with FULL_BACKTRACE=1 to see full backtrace" unless ENV['FULL_BACKTRACE']
-  end
-
-  def check_line_number!(line_number)
-    return line_number unless line_number.is_a?(String)
-    integer = line_number.to_i
-    if integer == 0
-      logger.error "ERROR: Think you accidentally passed in a String for the line_number: #{line_number}".color(:red)
-      puts caller
-      exit 1
-    end
-  end
 
   extend self
 end

--- a/lib/dsl_evaluator/printer/concern.rb
+++ b/lib/dsl_evaluator/printer/concern.rb
@@ -1,0 +1,63 @@
+class DslEvaluator::Printer
+  module Concern
+    # So other libraries can use this method
+    def print_code(*args)
+      if args.size == 2 # print_code(path, line_number)
+        path, line_number = args
+      else # print_code(caller_line)
+        # IE: .ufo/config/web/dev.rb:10:in `block in evaluate_file'
+        # User passed in a "standard" ruby backtrace call line
+        #   windows: "C:/Ruby31-x64/lib/ruby/gems/3.1.0/gems/terraspace-1.1.1/lib/terraspace/builder.rb:34:in `build'"
+        #   linux: "/home/ec2-user/.rvm/gems/ruby-3.0.3/gems/terraspace-1.1.1/lib/terraspace/compiler/dsl/syntax/mod.rb:4:in `<module:Mod>'"
+        caller_line = args[0]
+        parts = caller_line.split(':')
+        is_windows = caller_line.match(/^[a-zA-Z]:/)  # windows vs linux
+        calling_file = is_windows ? parts[1] : parts[0]
+        line_number  = is_windows ? parts[2] : parts[1]
+        path = calling_file
+      end
+
+      check_line_number!(line_number)
+      line_number = line_number.to_i
+
+      logger.info "Here's the original caller line from:"
+      logger.info pretty_path(path).color(:green)
+
+      contents = IO.read(path)
+      content_lines = contents.split("\n")
+      context = 5 # lines of context
+      top, bottom = [line_number-context-1, 0].max, line_number+context-1
+      lpad = content_lines.size.to_s.size
+      content_lines[top..bottom].each_with_index do |line_content, index|
+        current_line = top+index+1
+        if current_line == line_number
+          printf("%#{lpad}d %s\n".color(:red), current_line, line_content)
+        else
+          printf("%#{lpad}d %s\n", current_line, line_content)
+        end
+      end
+
+      logger.info "Rerun with FULL_BACKTRACE=1 to see full backtrace" unless ENV['FULL_BACKTRACE']
+    end
+
+    def check_line_number!(line_number)
+      return line_number unless line_number.is_a?(String)
+      integer = line_number.to_i
+      if integer == 0
+        logger.error "ERROR: Think you accidentally passed in a String for the line_number: #{line_number}".color(:red)
+        puts caller
+        exit 1
+      end
+    end
+
+    def pretty_path(path)
+      path.sub("#{Dir.pwd}/",'').sub(/^\.\//,'')
+    end
+
+    # Replace HOME with ~ - different from the main pretty_path
+    def pretty_home(path)
+      path.sub(ENV['HOME'], '~')
+    end
+  end
+end
+

--- a/lib/dsl_evaluator/printer/concern.rb
+++ b/lib/dsl_evaluator/printer/concern.rb
@@ -1,6 +1,8 @@
 class DslEvaluator::Printer
   module Concern
     # So other libraries can use this method
+    # The `print_code` method understands "polymorphic" arguments.
+    # See README.md
     def print_code(*args)
       if args.size == 2 # print_code(path, line_number)
         path, line_number = args

--- a/spec/dsl_evaluator/printer_spec.rb
+++ b/spec/dsl_evaluator/printer_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe DslEvaluator::Printer do
       error
     end
 
-    it "info" do
-      expect(printer.info).to eq({
+    it "error_info" do
+      expect(printer.error_info).to eq({
         :path=>"/tmp/infra/config/app.rb",
         :line_number=>"3"
       })


### PR DESCRIPTION
* The `print_code` method understands "polymorphic" arguments.
* Easier to use if the file and line number info can be gathered from a standard Ruby backtrace call line. Details in README